### PR TITLE
update: reduce wait time still fix flakiness

### DIFF
--- a/cypress/integration/4-search-results/search-results.spec.js
+++ b/cypress/integration/4-search-results/search-results.spec.js
@@ -19,7 +19,7 @@ describe("The Coda Collection Searching Section", () => {
         cy.get('[data-testid="searchPreview-input"]')
           .click()
           .type(searchData.bandName);
-        cy.wait(1000);
+        cy.wait(225);
         cy.get('[data-testid="searchPreview-artists"]')
           .find("a")
           .should("have.text", searchData.bandName);


### PR DESCRIPTION
Hello! 
Our team is investigating the impact of waiting time on flaky testing in asynchronous issues. We use your project and test code as one of our research data cases. Our experiments and test data have demonstrated that if the waiting time in the current test file is adjusted from 1000ms to 225ms, it can still guarantee the success of all 100 rerun tests, and can also mitigate the running time of test files to a certain extent.

The new waiting time can alleviate flakiness while saving test execution time compared to the original time values.

We appreciate your consideration and look forward to hearing your thoughts and feedback.